### PR TITLE
Fix inconsistency

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,6 +1,7 @@
 load("@bazel_gazelle//:def.bzl", "DEFAULT_LANGUAGES", "gazelle", "gazelle_binary")
 load("@com_github_bazelbuild_buildtools//buildifier:def.bzl", "buildifier")
 
+# gazelle:exclude .user.bazelrc
 # gazelle:exclude go.work.sum
 
 filegroup(

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -9,7 +9,6 @@ filegroup(
     srcs = [
         ".bazelrc",
         ".gitignore",
-        ".user.bazelrc",
         "BUILD.bazel",
         "README.md",
         "WORKSPACE",

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Add this into your WORKSPACE project
 http_archive(
     name = "com_github_sluongng_nogo_analyzer",
     sha256 = "ab9ab7936b6d490ff92bb8e3e03bc3ace3406f0b4d1625cc0720d0e9e81a369a",
+    strip_prefix = "nogo-analyzer-0.0.1",
     urls = [
         "https://github.com/sluongng/nogo-analyzer/archive/refs/tags/v0.0.1.tar.gz",
     ],

--- a/staticcheck/README.md
+++ b/staticcheck/README.md
@@ -34,7 +34,7 @@ STATICHECK_ANALYZERS = [
 
 nogo(
     name = "nogo",
-    deps = staticcheck_analyzers([STATICHECK_ANALYZERS]),
+    deps = staticcheck_analyzers(STATICHECK_ANALYZERS),
     visibility = ["//visibility:public"],
 )
 ```
@@ -44,7 +44,7 @@ Note here that `staticcheck_analyzers` return a list which can be combined with 
 ```
 nogo(
     name = "nogo",
-    deps = TOOLS_NOGO + staticcheck_analyzers([STATICHECK_ANALYZERS]),
+    deps = TOOLS_NOGO + staticcheck_analyzers(STATICHECK_ANALYZERS),
     visibility = ["//visibility:public"],
 )
 ```


### PR DESCRIPTION
1. STATICHECK_ANALYZERS already a list, no need to wrap it again.
2. Without strip_prefix your repo is unusable.
3. ".user.bazelrc" should be included in repo or excluded from BUILD file.