### PR TITLE
doc: staticcheck README

### DIFF
--- a/staticcheck/README.md
+++ b/staticcheck/README.md
@@ -17,7 +17,7 @@ load("@com_github_sluongng_nogo_analyzer//staticcheck:deps.bzl", "staticcheck_de
 staticcheck_deps()
 ```
 
-`gazelle_dependencies()` may contains an outdated version of `staticcheck` so you should load `staticcheck_deps()` before `gazelle_dependencies()` in WORKSPACE to ensure that the supported version is in used.
+**NOTE**: Make sure you load `staticcheck_deps()` before `gazelle_dependencies()`, as well as any other rules that use `go_repository`, because this can lead to dependency conflicts.
 
 Note that loading `staticcheck_deps()` is completely optional, advanced users may want to manage their own staticcheck dependencies separately in their WORKSPACE file.
 


### PR DESCRIPTION
It is actually critical to load `staticcheck_deps()` before `go_register_toolchains()`, but after `go_rules_dependencies()`, if you have any conflicting `go_repository` dependencies.

I ran into an issue with the project that requires `github.com/grpc-ecosystem/grpc-gateway/v2 v2.10.3` (witch depends on `honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc`).

For some reason just loading `staticcheck_deps()` before my `go_deps()` didn't do the work.
If needed example repo can be provided.