### PR TITLE
ci: setup BuildBuddy workflow

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -30,16 +30,20 @@ build --experimental_remote_cache_compression
 build --experimental_remote_merkle_tree_cache
 build --experimental_remote_merkle_tree_cache_size=10000
 
-build:remote-cache --bes_upload_mode=fully_async
-build:remote-cache --bes_results_url=https://app.buildbuddy.io/invocation/
-build:remote-cache --bes_backend=grpcs://remote.buildbuddy.io
-build:remote-cache --remote_cache=grpcs://remote.buildbuddy.io
-build:remote-cache --remote_timeout=3600
+# BuildBuddy config
+build:buildbuddy --remote_cache=grpcs://remote.buildbuddy.io
+build:buildbuddy --remote_timeout=3600
+
+build:buildbuddy-local --config=buildbuddy
+build:buildbuddy-local --bes_upload_mode=fully_async
+
+build:ci --config=buildbuddy
+test:ci --keep_going
 
 # Personal override (and creds)
 try-import .user.bazelrc
 
 ## Sample .user.bazelrc ##
 #
-# build --config=remote-cache
+# build --config=buildbuddy-local
 # build --remote_header=x-buildbuddy-api-key=<api-key>

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -15,6 +15,7 @@ filegroup(
         "LICENSE",
         "README.md",
         "WORKSPACE",
+        "buildbuddy.yaml",
         "def.bzl",
         "go.work",
         "//.github:all_files",

--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -1,0 +1,11 @@
+actions:
+  - name: "Test all targets"
+    triggers:
+      push:
+        branches:
+          - "master"
+      pull_request:
+        branches:
+          - "*"
+    bazel_commands:
+      - "test --config=ci //..."


### PR DESCRIPTION
Let's use BuildBuddy to reduce the burden of having to setup complicated
CI for the repository.
