### PR TITLE
golangci-lint: mark all targets as manual

### DIFF
--- a/golangci-lint/BUILD.bazel
+++ b/golangci-lint/BUILD.bazel
@@ -12,6 +12,7 @@ exports_files([
         name = analyzer,
         srcs = ["analyzer.go"],
         importpath = "github.com/sluongng/nogo-analyzer/golangci-lint/" + analyzer,
+        tags = ["manual"],
         visibility = ["//visibility:public"],
         x_defs = {"name": analyzer},
         deps = ["//golangci-lint/util"],
@@ -25,6 +26,7 @@ exports_files([
         size = "small",
         srcs = ["analyzer_test.go"],
         embed = [analyzer],
+        tags = ["manual"],
         # Only compatible with platforms which have sandbox execution support.
         # For more information see https://github.com/bazelbuild/rules_go/issues/3144
         target_compatible_with = select({

--- a/golangci-lint/tests/BUILD.bazel
+++ b/golangci-lint/tests/BUILD.bazel
@@ -9,6 +9,7 @@ go_bazel_test(
         "@io_bazel_rules_go//:all_files",
         "@bazel_gazelle//:all_files",
     ],
+    tags = ["manual"],
 )
 
 filegroup(


### PR DESCRIPTION
golangci-lint package has been very slow to build and executed due to a
bloated set of dependencies.

In the future when goci-lint is more mature, we would proceed to remove
golangci-lint from the source tree entirely.  Let's mark these slow
targets as manual only so that new contributor would not run into them
by default.