### PR TITLE
private/gen_deps: correctly handle EOF

### DIFF
--- a/private/gen_deps.bzl
+++ b/private/gen_deps.bzl
@@ -74,15 +74,15 @@ def copy_file_to_current_dir(name, from_target, to_file_name):
         name = name,
         outs = ["cp_file_{}.sh".format(to_file_name)],
         cmd = """
-        cat > $@ <<EOF
-        #!/bin/bash -x
+cat > $@ <<EOF
+#!/bin/bash
 
-        (
-            cd \\$$BUILD_WORKING_DIRECTORY || (echo 'could not find working directory' && exit 1)
-            cp -f \\$$BUILD_WORKSPACE_DIRECTORY/$(execpath {from_target}) {to_file}
-            chmod 644 {to_file}
-        )
-        """.format(
+(
+    cd \\$$BUILD_WORKING_DIRECTORY || (echo 'could not find working directory' && exit 1)
+    cp -f \\$$BUILD_WORKSPACE_DIRECTORY/$(execpath {from_target}) {to_file}
+    chmod 644 {to_file}
+)
+EOF""".format(
             from_target = from_target,
             to_file = to_file_name,
         ),


### PR DESCRIPTION
We used starlark multiline string which should not be indented.
The indentation made EOF not being recognized correctly.

Remove the indentation, added EOF, removed -x debug call.

This should help ease up the warning in BuildBuddy Workflow complaining
about this.