### PR TITLE
Make CI build results public

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -38,6 +38,10 @@ build:local-remote-cache --bes_upload_mode=fully_async
 build:workflows --config=buildbuddy_bes_backend
 build:workflows --config=buildbuddy_bes_results_url
 build:workflows --config=buildbuddy_remote_cache
+## TODO: remove this once BuildBuddy folks confirmed that 
+## the bug has been fixed on their end regarding command is 
+## not publicly displayed.
+build:workflows --build_metadata=VISIBILITY=PUBLIC
 test:workflows --keep_going
 
 # Personal override (and creds)


### PR DESCRIPTION
It seems like BuildBuddy has a bug where commands inside a workflows of
a public project could not be viewed by new contributors by default.

@bduffany suggested to add this metadata key-value pair as a work around.