### PR TITLE
goci-lint: deduplicate code in intergration test

### DIFF
--- a/goci-lint/tests/BUILD.bazel
+++ b/goci-lint/tests/BUILD.bazel
@@ -6,7 +6,10 @@ load("@io_bazel_rules_go//go/tools/bazel_testing:def.bzl", "go_bazel_test")
     go_bazel_test(
         name = i,
         size = "medium",
-        srcs = [i + "_test.go"],
+        srcs = [
+            i + "_test.go",
+            "util.go",
+        ],
         rule_files = [
             "@com_github_sluongng_nogo_analyzer//:all_files",
             "@io_bazel_rules_go//:all_files",
@@ -34,6 +37,7 @@ filegroup(
         "goimports_test.go",
         "ineffassign_test.go",
         "prealloc_test.go",
+        "util.go",
     ],
     visibility = ["//visibility:public"],
 )

--- a/goci-lint/tests/errcheck_test.go
+++ b/goci-lint/tests/errcheck_test.go
@@ -3,7 +3,6 @@ package goci_test
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"regexp"
 	"testing"
 
@@ -144,17 +143,4 @@ func TestErrcheck(t *testing.T) {
 			}
 		})
 	}
-}
-
-func replaceInFile(path, old, new string, once bool) error {
-	data, err := ioutil.ReadFile(path)
-	if err != nil {
-		return err
-	}
-	if once {
-		data = bytes.Replace(data, []byte(old), []byte(new), 1)
-	} else {
-		data = bytes.ReplaceAll(data, []byte(old), []byte(new))
-	}
-	return ioutil.WriteFile(path, data, 0o666)
 }

--- a/goci-lint/tests/gofmt_test.go
+++ b/goci-lint/tests/gofmt_test.go
@@ -3,7 +3,6 @@ package goci_test
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"regexp"
 	"testing"
 
@@ -130,17 +129,4 @@ func TestGofmt(t *testing.T) {
 			}
 		})
 	}
-}
-
-func replaceInFile(path, old, new string, once bool) error {
-	data, err := ioutil.ReadFile(path)
-	if err != nil {
-		return err
-	}
-	if once {
-		data = bytes.Replace(data, []byte(old), []byte(new), 1)
-	} else {
-		data = bytes.ReplaceAll(data, []byte(old), []byte(new))
-	}
-	return ioutil.WriteFile(path, data, 0o666)
 }

--- a/goci-lint/tests/goimports_test.go
+++ b/goci-lint/tests/goimports_test.go
@@ -3,7 +3,6 @@ package goci_test
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"strings"
 	"testing"
 
@@ -184,17 +183,4 @@ func TestGofmt(t *testing.T) {
 			}
 		})
 	}
-}
-
-func replaceInFile(path, old, new string, once bool) error {
-	data, err := ioutil.ReadFile(path)
-	if err != nil {
-		return err
-	}
-	if once {
-		data = bytes.Replace(data, []byte(old), []byte(new), 1)
-	} else {
-		data = bytes.ReplaceAll(data, []byte(old), []byte(new))
-	}
-	return ioutil.WriteFile(path, data, 0o666)
 }

--- a/goci-lint/tests/ineffassign_test.go
+++ b/goci-lint/tests/ineffassign_test.go
@@ -3,7 +3,6 @@ package goci_test
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"regexp"
 	"testing"
 
@@ -134,17 +133,4 @@ func TestErrcheck(t *testing.T) {
 			}
 		})
 	}
-}
-
-func replaceInFile(path, old, new string, once bool) error {
-	data, err := ioutil.ReadFile(path)
-	if err != nil {
-		return err
-	}
-	if once {
-		data = bytes.Replace(data, []byte(old), []byte(new), 1)
-	} else {
-		data = bytes.ReplaceAll(data, []byte(old), []byte(new))
-	}
-	return ioutil.WriteFile(path, data, 0o666)
 }

--- a/goci-lint/tests/prealloc_test.go
+++ b/goci-lint/tests/prealloc_test.go
@@ -3,7 +3,6 @@ package goci_test
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"regexp"
 	"testing"
 
@@ -140,17 +139,4 @@ func TestPrealloc(t *testing.T) {
 			}
 		})
 	}
-}
-
-func replaceInFile(path, old, new string, once bool) error {
-	data, err := ioutil.ReadFile(path)
-	if err != nil {
-		return err
-	}
-	if once {
-		data = bytes.Replace(data, []byte(old), []byte(new), 1)
-	} else {
-		data = bytes.ReplaceAll(data, []byte(old), []byte(new))
-	}
-	return ioutil.WriteFile(path, data, 0o666)
 }

--- a/goci-lint/tests/util.go
+++ b/goci-lint/tests/util.go
@@ -1,0 +1,19 @@
+package goci_test
+
+import (
+	"bytes"
+	"io/ioutil"
+)
+
+func replaceInFile(path, old, new string, once bool) error {
+	data, err := ioutil.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	if once {
+		data = bytes.Replace(data, []byte(old), []byte(new), 1)
+	} else {
+		data = bytes.ReplaceAll(data, []byte(old), []byte(new))
+	}
+	return ioutil.WriteFile(path, data, 0o666)
+}


### PR DESCRIPTION
No-op refactoring to move the duplicated code into a shared util file.