### PR TITLE
golangci_lint: make gen_deps manual

### DIFF
--- a/golangci-lint/BUILD.bazel
+++ b/golangci-lint/BUILD.bazel
@@ -42,6 +42,7 @@ generate_deps(
     name = "golangci_lint",
     mod_file = ":go.mod",
     sum_file = ":go.sum",
+    tags = ["manual"],
     targets = golangci_lint_analyzers(ANALYZERS, "//golangci-lint"),
 )
 


### PR DESCRIPTION
This seems to be taking a long time to executed(4m+)
Since we are not using golangci_lint much, let's make it opt-in.