### PR TITLE
fix: Broken test-deps

### DIFF
--- a/private/deps_test.bzl
+++ b/private/deps_test.bzl
@@ -25,7 +25,7 @@ def prune_ext_deps(name, targets, deps_file, size = "small", **kwargs):
         ],
         cmd = """
             grep '^@' $(location :{}_deps) |
-                sed 's|//.*||; s/@//' |
+                sed 's|//.*||; s/@//g' |
                 sort |
                 uniq > $@
         """.format(name),


### PR DESCRIPTION
Background
---

Fix the following broken tests by updating the sed command in `private/deps_test.bzl` to remove `@` globally

```
//goci-lint/errcheck:test_deps                                           FAILED in 0.4s
//goci-lint/gofmt:test_deps                                              FAILED in 0.4s
//goci-lint/goimports:test_deps                                          FAILED in 0.3s
//goci-lint/ineffassign:test_deps                                        FAILED in 0.4s
//goci-lint/prealloc:test_deps                                           FAILED in 0.4s
//staticcheck:test_deps                                                  FAILED in 0.3s
```

Update
---
These tests only fail in 7.2.0, as an alternate to this please see: https://github.com/sluongng/nogo-analyzer/pull/42